### PR TITLE
Remove jscs from dependencies, updating version under devDependencies.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -57,6 +57,9 @@
     "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
     "validthis"     : false,     // true: Tolerate using this in a non-constructor function
 
+    // environments
+    "node": true,
+
     // Legacy
     "onevar"        : true     // true: Allow only one `var` statement per function
 }

--- a/args.js
+++ b/args.js
@@ -1,4 +1,3 @@
-/*jshint node:true */
 "use strict";
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-/*jshint node:true*/
 "use strict";
 
 var fs   = require("fs"),

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,4 +1,3 @@
-/*jshint node:true */
 "use strict";
 
 var fs = require("fs"),

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
     "mocha": "~1.17.1",
     "istanbul": "~0.2.4",
     "jshint": "~2.4.4",
-    "jscs": "~1.2.4"
+    "jscs": "^1.3.0"
   },
   "dependencies": {
     "shelljs": "~0.2.6",
     "yui": "~3.14.1",
-    "nomnom": "~1.6.2",
-    "jscs": "~1.3.0"
+    "nomnom": "~1.6.2"
   }
 }


### PR DESCRIPTION
This makes `npm install .` actually work (previously, it was always installing `jscs` v1.2.4, which fails due to lack of `.jscrc` support). Yay!
