### PR TITLE
Add support for specifying filters

### DIFF
--- a/args.js
+++ b/args.js
@@ -1,6 +1,13 @@
 "use strict";
 
 module.exports = {
+    filters : {
+        string  : "-f FILTER, --filter=FILTER",
+        help    : "YUI file versions to include",
+        list    : true,
+        default : [ "min" ]
+    },
+    
     modules : {
         position : 0,
         help     : "YUI modules to package together",

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,9 @@ var fs   = require("fs"),
     path = require("path"),
 
     Y     = require("yui").use("loader"),
+    _     = {
+        unique : require("lodash.uniq")
+    },
     shell = require("shelljs"),
     
     templates = require("./templates"),
@@ -30,11 +33,44 @@ Clumper.prototype = {
         this._resolved = resolved;
     },
     
+    _filter : function() {
+        var filters  = [],
+            filtered = [];
+        
+        filters = this._args.filters
+            .map(function(filter) {
+                var def = loader.FILTER_DEFS[filter.toUpperCase()];
+                
+                if(!def) {
+                    return;
+                }
+                
+                def.searchExp = new RegExp(def.searchExp, "g");
+                
+                return def;
+            })
+            .filter(Boolean);
+        
+        if(!filters.length) {
+            this._filtered = this._resolved;
+        }
+        
+        this._resolved.forEach(function(file) {
+            filters.forEach(function(filter) {
+                filtered.push(file.replace(filter.searchExp, filter.replaceStr));
+            });
+            
+            filtered.push(file);
+        });
+        
+        this._filtered = _.unique(filtered);
+    },
+
     _copy : function() {
         var self = this,
             base = path.resolve(__dirname, "../node_modules/yui");
 
-        this._resolved.forEach(function(file) {
+        this._filtered.forEach(function(file) {
             var dest = path.join(self._args.output, path.relative(base, file));
             
             shell.mkdir("-p", path.dirname(dest));
@@ -84,6 +120,7 @@ Clumper.prototype = {
 
     run : function(done) {
         this._resolve();
+        this._filter();
         this._copy();
         this._create();
         this._package();

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "shelljs": "~0.2.6",
     "yui": "~3.14.1",
-    "nomnom": "~1.6.2"
+    "nomnom": "~1.6.2",
+    "lodash.uniq": "~2.4.1"
   }
 }


### PR DESCRIPTION
So you can control what files are copied. Uses the YUI filter defs so should be exactly accurate.
- `-min.js` always gets copied
- `raw` will copy `.js`
- `debug` will copy `-debug.js`
- `coverage` will copy `-coverage.js`

You can specify multiple, `-f raw -f debug -f coverage`.
